### PR TITLE
Fixed TimedExpire algorithm and test

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -22,8 +22,10 @@ sequential scan should not and *should* be taken care of by the processor
 automatically prefetching the next page before it is needed.
 **/
 type LeastRecentlyUsed struct {
-	counter int32
+	counter int64
 }
+
+func (rof *LeastRecentlyUsed) InitItem(item *MulticacheItem) {}
 
 func (rof *LeastRecentlyUsed) Reset(multicache *Multicache) {
 	rof.counter = 0

--- a/multicache.go
+++ b/multicache.go
@@ -238,5 +238,6 @@ func (mc *Multicache) getItem() *MulticacheItem {
 	// Remove all references to this item.
 	mc.removeItem(item)
 
+	mc.replace.InitItem(item)
 	return item
 }

--- a/multicacheitem.go
+++ b/multicacheitem.go
@@ -13,7 +13,7 @@ Licensed under the MIT license
 **/
 type MulticacheItem struct {
 	// The tag meaning is defined by the multicache algorithm being used.
-	Tag int32
+	Tag int64
 	// The set of keys that reference this item.
 	keys []string
 	// The actual item stored in this item.

--- a/replacement.go
+++ b/replacement.go
@@ -20,6 +20,8 @@ ReplacementAlgorithm. For example, you could use Tag to store an increasing
 number if you were creating an LRU style replacement.
 **/
 type ReplacementAlgorithm interface {
+	// Initialize the item
+	InitItem(*MulticacheItem)
 	// Resets the items in the multicache
 	Reset(multicache *Multicache)
 	// Gets the next item to replace

--- a/round_robin.go
+++ b/round_robin.go
@@ -17,6 +17,8 @@ type RoundRobin struct {
 	position uint64
 }
 
+func (rof *RoundRobin) InitItem(item *MulticacheItem) {}
+
 func (rof *RoundRobin) Reset(multicache *Multicache) {
 	rof.position = 0
 }

--- a/second_chance.go
+++ b/second_chance.go
@@ -23,6 +23,8 @@ type SecondChance struct {
 	position uint64
 }
 
+func (rof *SecondChance) InitItem(item *MulticacheItem) {}
+
 func (rof *SecondChance) Reset(multicache *Multicache) {
 	rof.position = 0
 }

--- a/time_expire.go
+++ b/time_expire.go
@@ -1,9 +1,6 @@
 package multicache
 
-import (
-	"math"
-	"time"
-)
+import "time"
 
 /**
 This file is part of multicache, a library for handling caches with multiple
@@ -12,10 +9,6 @@ keys and replacement algorithms.
 Copyright 2015 Joseph Lewis <joseph@josephlewis.net>
 Licensed under the MIT license
 **/
-
-const (
-	nsToMs float64 = 1e-6
-)
 
 /**
 
@@ -27,7 +20,11 @@ amount of time remaining will be replaced.
 
 **/
 type TimedExpire struct {
-	timeExpireMs float64
+	timeExpireMs int64
+}
+
+func (this *TimedExpire) InitItem(item *MulticacheItem) {
+	item.Tag = time.Now().UnixNano() / int64(time.Millisecond)
 }
 
 func (this *TimedExpire) Reset(multicache *Multicache) {
@@ -35,21 +32,22 @@ func (this *TimedExpire) Reset(multicache *Multicache) {
 
 func (this *TimedExpire) GetNextReplacement(multicache *Multicache) *MulticacheItem {
 
-	currentTimeMs := float64(time.Now().Nanosecond()) * nsToMs
+	currentTimeMs := time.Now().UnixNano() / int64(time.Millisecond)
 
-	difference := math.MaxFloat64
+	var difference int64 = 0
 	var smallestItem *MulticacheItem
 
 	for _, item := range multicache.itemList {
-		itemTime := float64(item.Tag)
-		timeDelta := currentTimeMs - itemTime
+		// item.Tag has the creation time of this item
+		timeDelta := currentTimeMs - item.Tag
 
 		// short circuit the rest of the items.
-		if timeDelta <= this.timeExpireMs {
+		if timeDelta >= this.timeExpireMs {
 			return item
 		}
 
-		if timeDelta < difference {
+		// stored older item
+		if timeDelta > difference {
 			difference = timeDelta
 			smallestItem = item
 		}
@@ -65,11 +63,10 @@ func (this *TimedExpire) UpdatesOnRetrieved() bool {
 func (this *TimedExpire) ItemRetrieved(item *MulticacheItem) bool {
 	// Make sure the item is still valid.
 
-	currentTimeMs := float64(time.Now().Nanosecond()) * nsToMs
-	itemTime := float64(item.Tag)
-	timeDelta := currentTimeMs - itemTime
+	currentTimeMs := time.Now().UnixNano() / int64(time.Millisecond)
+	timeDelta := currentTimeMs - item.Tag
 
-	isValid := timeDelta >= this.timeExpireMs
+	isValid := timeDelta <= this.timeExpireMs
 
 	return isValid
 }
@@ -78,13 +75,13 @@ func (this *TimedExpire) ItemRetrieved(item *MulticacheItem) bool {
 Creates a new multicache that removes items inserted before expireTimeMs milliseconds
 ago with numItems slots for items.
 **/
-func CreateTimeExpireMulticache(numItems, expireTimeMs uint64) (*Multicache, error) {
+func CreateTimeExpireMulticache(numItems uint64, expireTimeMs int64) (*Multicache, error) {
 	return NewMulticache(numItems, CreateTimeExpireAlgorithm(expireTimeMs))
 }
 
 /**
 Creates a timed expire algorithm.
 **/
-func CreateTimeExpireAlgorithm(expireTimeMs uint64) *TimedExpire {
-	return &TimedExpire{float64(expireTimeMs)}
+func CreateTimeExpireAlgorithm(expireTimeMs int64) *TimedExpire {
+	return &TimedExpire{expireTimeMs}
 }

--- a/time_expire_test.go
+++ b/time_expire_test.go
@@ -16,11 +16,14 @@ var timedExpireTestCases = []ReplacementAlgorithmTestcase{
 	// Hit all items because they don't expire
 	{&TimedExpire{100}, 2, []string{"a", "a", "a", "b", "b"}, []bool{false, true, true, false, true}, 1},
 	// Overwrite the first element and try it again
-	{&TimedExpire{5}, 2, []string{"a", "b", "c", "a", "b"}, []bool{false, false, false, false, true}, 1}}
+	{&TimedExpire{100}, 2, []string{"a", "b", "c", "a", "c"}, []bool{false, false, false, false, true}, 1},
+	// Miss the item when expired
+	{&TimedExpire{250}, 10, []string{"a", "a", "a", "a", "a"}, []bool{false, true, true, false, true}, 100},
+}
 
 func TestTimedExpire(t *testing.T) {
 
-	for _, testcase := range roundRobinTestCases {
+	for _, testcase := range timedExpireTestCases {
 		testcase.RunTest(t)
 	}
 }


### PR DESCRIPTION
This PR fixed TimedExpire test and the expired cache logic.
- Changed from `time.Nanosecond` to `time.UnixNano` to evaluate time
- Save the creation time into `MulticacheItem.Tag` when the item added
  - Implemented `InitItem` for every `ReplacementAlgorithm` inerface
  - Upgraded precision from int32 to int64 to compare unix time millisec
